### PR TITLE
Remove babel-plugin-version-inline

### DIFF
--- a/extras.js
+++ b/extras.js
@@ -5,9 +5,7 @@ module.exports = {
         // default: "bar" -> "default": "bar"
         require('babel-plugin-transform-es3-property-literals'),
         // "use strict"
-        require('babel-plugin-transform-strict-mode'),
-        // __VERSION__
-        require('babel-plugin-version-inline').default
+        require('babel-plugin-transform-strict-mode')
     ],
     sourceMaps: "inline"
 };

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "babel-plugin-transform-function-bind": "^6.5.2",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-plugin-transform-regenerator": "^6.6.5",
-    "babel-plugin-transform-strict-mode": "^6.6.5",
-    "babel-plugin-version-inline": "^1.0.0"
+    "babel-plugin-transform-strict-mode": "^6.6.5"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5"


### PR DESCRIPTION
Unfortunately, I can't use this module as it stands because I'm using babel in a directory without a `package.json` which makes `babel-plugin-version-inline` throw an error. This is a module which could easily be configured in a `.babelrc` file without needing to be in this un-opinionated preset 😊
